### PR TITLE
Add appCode to CachedResponseClient

### DIFF
--- a/src/CachedResponseClient.php
+++ b/src/CachedResponseClient.php
@@ -31,6 +31,11 @@ class CachedResponseClient implements HttpClient
      * @var null|string
      */
     private $apiKey;
+    
+    /**
+     * @var null|string
+     */
+    private $appCode;
 
     /**
      * @var string
@@ -41,12 +46,15 @@ class CachedResponseClient implements HttpClient
      * @param HttpClient  $delegate
      * @param string      $cacheDir
      * @param string|null $apiKey
+     * @param string|null $appCode
      */
-    public function __construct(HttpClient $delegate, $cacheDir, $apiKey = null)
+    public function __construct(HttpClient $delegate, $cacheDir, $apiKey = null, $appCode = null)
     {
         $this->delegate = $delegate;
         $this->cacheDir = $cacheDir;
         $this->apiKey = $apiKey;
+        $this->appCode = $appCode;
+
     }
 
     /**
@@ -61,6 +69,9 @@ class CachedResponseClient implements HttpClient
         }
         if (!empty($this->apiKey)) {
             $cacheKey = str_replace($this->apiKey, '[apikey]', $cacheKey);
+        }
+        if (!empty($this->appCode)) {
+            $cacheKey = str_replace($this->appCode, '[appCode]', $cacheKey);
         }
 
         $file = sprintf('%s/%s_%s', $this->cacheDir, $host, sha1($cacheKey));

--- a/src/CachedResponseClient.php
+++ b/src/CachedResponseClient.php
@@ -54,7 +54,6 @@ class CachedResponseClient implements HttpClient
         $this->cacheDir = $cacheDir;
         $this->apiKey = $apiKey;
         $this->appCode = $appCode;
-
     }
 
     /**

--- a/src/CachedResponseClient.php
+++ b/src/CachedResponseClient.php
@@ -31,7 +31,7 @@ class CachedResponseClient implements HttpClient
      * @var null|string
      */
     private $apiKey;
-    
+
     /**
      * @var null|string
      */


### PR DESCRIPTION
Add `appCode` to `CachedResponseClient` for providers which require 2 keys (Here and Algolia places). 
(ref PR Geocoder [#844](https://github.com/geocoder-php/Geocoder/pull/844))