### PR TITLE
feat: drop support for PHP < 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "nyholm/psr7": "^1.0",
         "php-http/curl-client": "^2.2",
         "php-http/mock-client": "^1.2",


### PR DESCRIPTION
https://github.com/geocoder-php/provider-integration-tests/issues/25

Because of typed properties, PHP 7.3 will not work.
https://github.com/geocoder-php/provider-integration-tests/blob/master/src/ProviderIntegrationTest.php#L46